### PR TITLE
building: Addition of deep code signing capability for MacOS.

### DIFF
--- a/PyInstaller/building/build_main.py
+++ b/PyInstaller/building/build_main.py
@@ -840,5 +840,6 @@ def main(pyi_config, specfile, noconfirm, ascii=False, **kw):
 
     CONF['ui_admin'] = kw.get('ui_admin', False)
     CONF['ui_access'] = kw.get('ui_uiaccess', False)
+    CONF['codesign_identity'] = kw.get('codesign_identity', None)
 
     build(specfile, kw.get('distpath'), kw.get('workpath'), kw.get('clean_build'))

--- a/PyInstaller/building/makespec.py
+++ b/PyInstaller/building/makespec.py
@@ -280,6 +280,14 @@ def __add_options(parser):
                         'name for code signing purposes. The usual form is a hierarchical name '
                         'in reverse DNS notation. For example: com.mycompany.department.appname '
                         "(default: first script's basename)")
+    g.add_argument('--osx-codesign-identity', dest='codesign_identity',
+                   help='If this option is given, all binaries packaged in the'
+                        ' app, including the app bundle itself, will be code '
+                        'signed using the ``codesign`` utility provided by '
+                        'Xcode Developer Tools. Make sure the utility is in '
+                        'your PATH and that the identity specified is valid '
+                        'for code signing, '
+                        'e.g. \'Developer ID Application: Your Name\'')
 
     g = parser.add_argument_group('Rarely used special options')
     g.add_argument("--runtime-tmpdir", dest="runtime_tmpdir", metavar="PATH",

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -418,6 +418,24 @@ and for more detail, the `Apple code signing overview`_ technical note).
 You can add other items to the :file:`Info.plist` by editing the spec file;
 see :ref:`Spec File Options for a Mac OS X Bundle` below.
 
+Code Signing Embedded Binaries
+-------------------
+
+You may also optionally specify that |PyInstaller| code sign all binaries which
+get embedded into your built application (such as the Python interpreter, its
+.so files, .dylib files for packages such as PyQt, etc). To enable code signing
+of embedded binaries, use the ``--osx-codesign-identity`` command-line option
+(or ``codesign_identity=`` kw arg). This facility requires the ``codesign``
+utility (which comes installed with a full install of Xcode) be present in your
+PATH.
+
+The identity argument must be a valid code signing identity installed on the
+system obtained via Apple's Developer program. Code signing identities are
+usually of the form: "Developer ID Application: YOUR NAME".
+
+Using this option will also cause |PyInstaller| to sign any generated ``.app``
+bundle with the same identity.
+
 
 Platform-specific Notes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/news/3991.feature.rst
+++ b/news/3991.feature.rst
@@ -1,0 +1,2 @@
+Addition of embedded binary code signing capability for MacOS using the
+``--osx-codesign-identity`` command-line option.


### PR DESCRIPTION
OSX only: If --osx-codesign-identity is specified on the command-line,
then we use the Xcode Developer Tools `codesign` utility to sign all
embedded binaries as well as the .app bundle itself. Note that this
option may also be given as the `codesign_identity` kwarg to PKG and
BUNDLE for finer-grained control as well.

If this option is omitted, the default is off (no code siging is
performed).

The motivation for this change is the following:

* Previous to this change, pyinstaller would inadvertently invalidate
  signed binaries because it would would modify the Mach-O loader table.
  Most binaries are not signed -- so this isn't an issue most of the
  time. But in the rare circumstance that a signed binary was being
  packaged by pyintaller, it could lead to a situation where the
  modified binary becomes invalidated. So a re-signing of embedded
  binaries would be necessary to correct the situation, which this new
  --osx-codesign-identity facility provides.

* To ensure that embedded binaries are properly signed, which may become
  a requirement in a future version of MacOS in order to have full
  access to all OS services (camera, microphone, etc). In addition, code
  signing of all binaries should allow developers to properly notarize
  apps and is compatible with Apple's new 'hardened runtime' feature
  introduced in MacOS 10.14 Mojave.

Notes:

* The codesign utility is normally installed and placed in the path with
  a full installation of Xcode.

* The "codesign identity" is a MacOS specific concept that associates a
  string to a developer certificate and a private key. The identity
  usually takes the form "Developer ID Application: YOUR NAME". The
  codesign utility expects this identity as a parameter so that it
  knows which developer certificate and keys to use for signing. One
  obtains the required certificates and keys from Apple's developer
  website (an Apple developer subscription is required).

* Code signing is performed by signing all binaries that get embedded &
  packaged into the final build product. This must be done after
  binaries are modified by pyinstaller (binaries are sometimes modified
  and given a @loader_path in the Mach-O loader table so they link
  properly). The binaries themselves are first copied into the local
  pyinstaller cache, modified with a @loader_path, and then signed.